### PR TITLE
docs: add links to license and release badges in READMEs

### DIFF
--- a/README-zh_TW.md
+++ b/README-zh_TW.md
@@ -7,7 +7,7 @@
 `kubectl-jqlogs` 的運作方式與 `kubectl logs` 完全相同，但內建了 `jq` 引擎，可自動美化 JSON 輸出。無需管線 (pipes)，無需額外工具，開箱即由，提供乾淨、可查詢的日誌。
 
 [![License](https://img.shields.io/github/license/shihyuho/kubectl-jqlogs)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/shihyuho/kubectl-jqlogs)](https://github.com/shihyuho/kubectl-jqlogs/releases)
+[![Release](https://img.shields.io/github/v/release/shihyuho/kubectl-jqlogs)](https://github.com/shihyuho/kubectl-jqlogs/releases/latest)
 
 
 ## ✨ 特色

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `kubectl-jqlogs` works exactly like `kubectl logs`, but with a built-in `jq` engine that automatically prettifies JSON output. No pipes, no extra tools—just clean, queryable logs out of the box.
 
 [![License](https://img.shields.io/github/license/shihyuho/kubectl-jqlogs)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/shihyuho/kubectl-jqlogs)](https://github.com/shihyuho/kubectl-jqlogs/releases)
+[![Release](https://img.shields.io/github/v/release/shihyuho/kubectl-jqlogs)](https://github.com/shihyuho/kubectl-jqlogs/releases/latest)
 
 
 


### PR DESCRIPTION
## Description
Adds links to the License and Release badges in `README.md` and `README-zh_TW.md` for better navigation.

## Changes
- Link license badge to `LICENSE`
- Link release badge to GitHub Releases page
- Link "MIT" text to `LICENSE`