### PR TITLE
perf: stream pre-filtering and Runner refactoring

### DIFF
--- a/pkg/jqlogs/runner.go
+++ b/pkg/jqlogs/runner.go
@@ -1,0 +1,130 @@
+package jqlogs
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/itchyny/gojq/cli"
+)
+
+// Runner manages the execution pipeline
+type Runner struct {
+	Stdout      io.Writer
+	Stderr      io.Writer
+	ExecKubectl func(args []string, stdout io.Writer, stderr io.Writer) error
+	ExecJq      func(args []string, stdin io.Reader) int
+}
+
+// NewDefaultRunner creates a runner with real dependencies
+func NewDefaultRunner() *Runner {
+	return &Runner{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		ExecKubectl: func(args []string, stdout io.Writer, stderr io.Writer) error {
+			cmd := exec.Command("kubectl", append([]string{"logs"}, args...)...)
+			cmd.Env = os.Environ()
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			return cmd.Wait()
+		},
+		ExecJq: func(args []string, stdin io.Reader) int {
+			// Save originals
+			oldArgs := os.Args
+			oldStdin := os.Stdin
+			defer func() {
+				os.Args = oldArgs
+				os.Stdin = oldStdin
+			}()
+
+			os.Args = args
+
+			// We must pass an *os.File to gojq because it checks if it's a terminal.
+			// When piping in real life, it is an *os.File.
+			if f, ok := stdin.(*os.File); ok {
+				os.Stdin = f
+			}
+			return cli.Run()
+		},
+	}
+}
+
+// Run executes the kubectl -> stream filter -> jq logs pipeline. Returns exit code.
+func (r *Runner) Run(kubectlArgs []string, jqQuery string, opts JqFlagOptions) int {
+	// Pipe between kubectl and our Scanner
+	kPr, kPw, err := os.Pipe()
+	if err != nil {
+		fmt.Fprintf(r.Stderr, "Error creating pipe: %v\n", err)
+		return 1
+	}
+
+	// Pipe between our Scanner and JQ
+	jqPr, jqPw, err := os.Pipe()
+	if err != nil {
+		fmt.Fprintf(r.Stderr, "Error creating pipe: %v\n", err)
+		return 1
+	}
+
+	// 1. Start kubectl asynchronously
+	go func() {
+		defer kPw.Close()
+		err := r.ExecKubectl(kubectlArgs, kPw, r.Stderr)
+		if err != nil {
+			// Note: If kubectl fails (e.g. pod not found), standard error is already written to r.Stderr.
+			// gojq will read EOF and exit normally.
+		}
+	}()
+
+	// 2. Start Scanner (Filter) asynchronously
+	go func() {
+		defer jqPw.Close() // closing this tells JQ we are done sending JSON
+		scanner := bufio.NewScanner(kPr)
+
+		// To handle very long lines, allow up to 1MB line buffer
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, 1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				fmt.Fprintln(r.Stdout)
+				continue
+			}
+
+			// Pre-filter logic: skip leading whitespaces to find first char
+			isJSON := false
+			for _, b := range line {
+				if b == ' ' || b == '\t' || b == '\r' || b == '\n' {
+					continue
+				}
+				if b == '{' || b == '[' {
+					isJSON = true
+				}
+				break
+			}
+
+			if isJSON {
+				// Send to JQ pipe
+				jqPw.Write(line)
+				jqPw.Write([]byte{'\n'})
+			} else {
+				// Bypass JQ, print directly to Stdout.
+				r.Stdout.Write(line)
+				r.Stdout.Write([]byte{'\n'})
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(r.Stderr, "Error reading log stream: %v\n", err)
+		}
+	}()
+
+	// 3. Run JQ synchronously
+	jqArgs := BuildJqArgs(jqQuery, opts)
+	return r.ExecJq(jqArgs, jqPr)
+}

--- a/pkg/jqlogs/runner_test.go
+++ b/pkg/jqlogs/runner_test.go
@@ -1,0 +1,131 @@
+package jqlogs
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunner_Run_Success(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	runner := &Runner{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		// Mock ExecKubectl
+		ExecKubectl: func(args []string, stdout io.Writer, stderr io.Writer) error {
+			stdout.Write([]byte("mock log line 1\n"))
+			return nil
+		},
+		// Mock ExecJq
+		ExecJq: func(args []string, stdin io.Reader) int {
+			data, _ := io.ReadAll(stdin)
+			// In our mock, jq just capitalizes the input to prove it ran
+			stdout.Write([]byte(strings.ToUpper(string(data))))
+			return 0
+		},
+	}
+
+	kubectlArgs := []string{"-n", "default", "pod"}
+	jqQuery := "."
+	opts := JqFlagOptions{}
+
+	// Add a WaitGroup or Channel to ensure the goroutine writing to stdout finishes
+	// Since ExecJq is synchronous and returns right away in our mock,
+	// the test hits the assertions BEFORE the Runner's scanner goroutine finishes copying to stdout.
+	done := make(chan bool)
+	go func() {
+		exitCode := runner.Run(kubectlArgs, jqQuery, opts)
+		if exitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", exitCode)
+		}
+		done <- true
+	}()
+	<-done
+
+	// We still need a tiny delay because Runner.Run returns ExecJq immediately,
+	// but the scanner is running asynchronously. A better way in tests is to wait for the pipe to close.
+	// Since our runner does not expose the waitgroup, we'll just sleep briefly for the test.
+	time.Sleep(50 * time.Millisecond)
+
+	outStr := stdout.String()
+	// Because of filtering, plain text is NO LONGER sent to jq, so it won't be uppercased.
+	if !strings.Contains(outStr, "mock log line 1") {
+		t.Errorf("expected output to contain 'mock log line 1', got %q", outStr)
+	}
+}
+
+func TestRunner_Run_Filtering(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	// We need an io.Pipe to simulate jq reading stream, but writing to memory to avoid deadlocks
+	// in the mock ExecJq returning immediately
+	var mockJqOut bytes.Buffer
+
+	runner := &Runner{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		ExecKubectl: func(args []string, out io.Writer, err io.Writer) error {
+			out.Write([]byte("plain text log 1\n"))
+			out.Write([]byte("{\"level\":\"info\",\"msg\":\"json log 1\"}\n"))
+			out.Write([]byte("  [1, 2, 3]\n")) // starts with space then array
+			out.Write([]byte("plain text log 2\n"))
+			return nil
+		},
+		ExecJq: func(args []string, stdin io.Reader) int {
+			// Read from passed stdin (which should only contain JSON lines now)
+			// We copy it to stdout with a prefix to indicate JQ processed it
+
+			// To avoid blocking, we read everything first
+			data, _ := io.ReadAll(stdin)
+
+			// Now we write out the simulated JQ output
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+			for _, l := range lines {
+				if l != "" {
+					mockJqOut.Write([]byte("JQ_PROCESSED: " + l + "\n"))
+				}
+			}
+
+			// Simulate jq output streaming back to stdout
+			io.Copy(&stdout, &mockJqOut)
+			return 0
+		},
+	}
+
+	exitCode := runner.Run([]string{}, ".", JqFlagOptions{})
+	if exitCode != 0 {
+		t.Errorf("expected 0, got %d", exitCode)
+	}
+
+	// Wait a tiny bit for the stdout writes from the scanner's plain text to finish flushing
+	time.Sleep(50 * time.Millisecond)
+
+	outStr := stdout.String()
+
+	// What we EXPECT is that the Runner sends JSON to JQ and plain text to stdout.
+	// Since our Mock JQ prefixes everything IT receives with JQ_PROCESSED,
+	// if the Runner is broken and sends EVERYTHING to JQ, the plain text will ALSO
+	// have JQ_PROCESSED.
+
+	// Plain text should NOT have JQ_PROCESSED prefix
+	if strings.Contains(outStr, "JQ_PROCESSED: plain text log 1") {
+		t.Errorf("Plain text log was sent to JQ. Output: %s", outStr)
+	}
+	if !strings.Contains(outStr, "plain text log 1") { // newline check removed to be safe on cross-platform trims
+		t.Errorf("Missing untouched plain text log. Output: %s", outStr)
+	}
+
+	// JSON lines SHOULD have JQ_PROCESSED prefix
+	if !strings.Contains(outStr, "JQ_PROCESSED: {\"level\":\"info\",\"msg\":\"json log 1\"}") {
+		t.Errorf("Missing JQ processed json. Output: %s", outStr)
+	}
+	// For the array, we expect the leading spaces to be preserved because gojq will receive it as is
+	if !strings.Contains(outStr, "JQ_PROCESSED:   [1, 2, 3]") {
+		t.Errorf("Missing JQ processed array. Output: %s", outStr)
+	}
+}


### PR DESCRIPTION
## Summary
- Refactored `cmd/root.go` to use a testable `Runner` interface.
- Implemented Go-level stream pre-filtering in `Runner.Run` using `bufio.Scanner` to bypass `jq` processing for non-JSON lines, massively improving CPU performance on plain-text heavy pods.
- Added comprehensive unit tests for `Runner` with mocking.

## Test Plan
- [x] Unit tests pass (`go test ./...` in `pkg/jqlogs`)
- [x] Integration tests pass
